### PR TITLE
Addition of variable JPEG2000 compression for different sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ build/*
 xcuserdata
 profile
 *.moved-aside
+
+# OS X Finder
+.DS_Store


### PR DESCRIPTION
Make specified JPEG2000 compression apply variably across different icon sizes.  Results in much smaller overall size with no visible loss of quality by allowing higher JPEG2000 compression level to be specified.

From the main commit note:

High JPEG2000 compression levels result in excellent results at large image dimensions, but can cause very visible artefacting for smaller icon dimensions.  This commit applies the specified compression level for the large image sizes, applies less compression for 512_512 and 256_256 sizes, and disables compression for smaller sizes; this allows JPEG2000 compression to be increased overall for much smaller file sizes with no visible loss in quality, producing excellent output at compression levels of 0.2-05 for most icons.

Also outputs the compression level being used for each size in the output
